### PR TITLE
Update Standalone image tests 

### DIFF
--- a/test/npmap-symbol-library.test.js
+++ b/test/npmap-symbol-library.test.js
@@ -29,7 +29,7 @@ test('NPMap Symbol Library', function (t) {
     t.equal(typeof f.icon, 'string', 'icon property');
     t.equal(typeof f.release, 'string', 'release property');
     t.equal(typeof f.tags, 'object', 'tags property');
-    [16, 24, 32].forEach(function (size) {
+    [14, 22, 30].forEach(function (size) {
       t.doesNotThrow(function () {
         fs.statSync(__dirname + '/../src/standalone/' + f.icon + '-' + size + '.svg');
         fs.statSync(__dirname + '/../renders/standalone/' + f.icon + '-' + size + '.png');


### PR DESCRIPTION
Updated tests against the Standalone directory images to check for 14, 22, and 30 sizes from 16, 24, 32. (This fixes 1662 failing tests)

After Updates:
![image](https://user-images.githubusercontent.com/9942473/67434607-2678a200-f5b0-11e9-8a29-5b2f11591477.png)
